### PR TITLE
jwt 세팅 및 로그인 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.0-SNAPSHOT'
+	id 'org.springframework.boot' version '3.2.1'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -27,10 +27,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// spring security
+	implementation("org.springframework.boot:spring-boot-starter-security")
+
+	// jwt
+	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'

--- a/src/main/java/com/footbolic/api/FootbolicApplication.java
+++ b/src/main/java/com/footbolic/api/FootbolicApplication.java
@@ -20,7 +20,8 @@ public class FootbolicApplication {
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
 						.allowedOrigins("http://localhost:5173")
-						.allowedMethods("GET", "POST", "PATCH", "DELETE");
+						.allowedMethods("GET", "POST", "PATCH", "DELETE")
+						.allowCredentials(true);
 			}
 		};
 	}

--- a/src/main/java/com/footbolic/api/authorization/repository/AuthorizationRepositoryCustom.java
+++ b/src/main/java/com/footbolic/api/authorization/repository/AuthorizationRepositoryCustom.java
@@ -1,5 +1,11 @@
 package com.footbolic.api.authorization.repository;
 
+import com.footbolic.api.authorization.entity.AuthorizationEntity;
+import com.footbolic.api.role.entity.RoleEntity;
+
+import java.util.List;
+
 public interface AuthorizationRepositoryCustom {
 
+    List<AuthorizationEntity> findAllAuthorizationsByRole(RoleEntity role);
 }

--- a/src/main/java/com/footbolic/api/authorization/repository/AuthorizationRepositoryCustomImpl.java
+++ b/src/main/java/com/footbolic/api/authorization/repository/AuthorizationRepositoryCustomImpl.java
@@ -1,8 +1,14 @@
 package com.footbolic.api.authorization.repository;
 
+import com.footbolic.api.authorization.entity.AuthorizationEntity;
+import com.footbolic.api.role.entity.RoleEntity;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.footbolic.api.authorization.entity.QAuthorizationEntity.authorizationEntity;
 
 @Repository
 @RequiredArgsConstructor
@@ -10,4 +16,9 @@ public class AuthorizationRepositoryCustomImpl implements AuthorizationRepositor
 
     private final JPAQueryFactory queryFactory;
 
+    @Override
+    public List<AuthorizationEntity> findAllAuthorizationsByRole(RoleEntity role) {
+        return queryFactory.selectFrom(authorizationEntity)
+                .where(authorizationEntity.roleId.eq(role.getId())).fetch();
+    }
 }

--- a/src/main/java/com/footbolic/api/authorization/service/AuthorizationService.java
+++ b/src/main/java/com/footbolic/api/authorization/service/AuthorizationService.java
@@ -1,6 +1,7 @@
 package com.footbolic.api.authorization.service;
 
 import com.footbolic.api.authorization.dto.AuthorizationDto;
+import com.footbolic.api.role.dto.RoleDto;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public interface AuthorizationService {
 
     List<AuthorizationDto> findAllAuthorizations(Pageable pageable);
+
+    List<AuthorizationDto> findAllAuthorizationsByRole(RoleDto role);
 
     AuthorizationDto findById(String id);
 

--- a/src/main/java/com/footbolic/api/authorization/service/AuthorizationServiceImpl.java
+++ b/src/main/java/com/footbolic/api/authorization/service/AuthorizationServiceImpl.java
@@ -3,6 +3,7 @@ package com.footbolic.api.authorization.service;
 import com.footbolic.api.authorization.repository.AuthorizationRepository;
 import com.footbolic.api.authorization.dto.AuthorizationDto;
 import com.footbolic.api.authorization.entity.AuthorizationEntity;
+import com.footbolic.api.role.dto.RoleDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,13 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     public List<AuthorizationDto> findAllAuthorizations(Pageable pageable) {
         return authorizationRepository.findAll(pageable).stream().map(AuthorizationEntity::toDto).toList();
     }
+
+    @Override
+    public List<AuthorizationDto> findAllAuthorizationsByRole(RoleDto role) {
+        return authorizationRepository.findAllAuthorizationsByRole(role.toEntity())
+                .stream().map(AuthorizationEntity::toDto).toList();
+    }
+
 
     @Override
     public AuthorizationDto findById(String id) {

--- a/src/main/java/com/footbolic/api/common/service/CustomUserDetailsService.java
+++ b/src/main/java/com/footbolic/api/common/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.footbolic.api.common.service;
+
+import com.footbolic.api.member.entity.MemberEntity;
+import com.footbolic.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow(() ->
+                new UsernameNotFoundException("사용자가 존재하지 않습니다."));
+        return new User(memberId, "",  List.of(new SimpleGrantedAuthority(member.getRoleId())));
+    }
+}

--- a/src/main/java/com/footbolic/api/config/WebSecurityConfig.java
+++ b/src/main/java/com/footbolic/api/config/WebSecurityConfig.java
@@ -1,0 +1,43 @@
+package com.footbolic.api.config;
+
+import com.footbolic.api.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            HandlerMappingIntrospector introspector
+    ) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
+                        .requestMatchers(new AntPathRequestMatcher("/sign/**")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/members/public/**")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/members", "POST")).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/footbolic/api/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/footbolic/api/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.footbolic.api.filter;
+
+import com.footbolic.api.common.service.CustomUserDetailsService;
+import com.footbolic.api.member.dto.MemberDto;
+import com.footbolic.api.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final CustomUserDetailsService userDetailsService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        MemberDto member = Optional.ofNullable(jwtUtil.extractAccessToken(request))
+                .filter(jwtUtil::validateToken)
+                .map(jwtUtil::resolveAccessToken)
+                .filter(e -> e.getAccessTokenExpiresAt().isAfter(LocalDateTime.now()))
+                .filter(e -> e.getRoleId() != null && !e.getRoleId().isEmpty())
+                .orElse(null);
+
+        if (member != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(member.getId());
+
+            if (userDetails != null) {
+                UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/footbolic/api/member/dto/MemberDto.java
+++ b/src/main/java/com/footbolic/api/member/dto/MemberDto.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 
 @Schema(name = "Member 객체")
 @Data
@@ -37,12 +38,6 @@ public class MemberDto {
     @DateTimeFormat(pattern="yyyy-MM-ddTHH:mm:ss")
     private LocalDateTime accessTokenExpiresAt;
 
-    private String idToken;
-
-    private String scope;
-
-    private String tokenType;
-
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
@@ -59,9 +54,6 @@ public class MemberDto {
                 .refreshTokenExpiresAt(refreshTokenExpiresAt)
                 .accessToken(accessToken)
                 .accessTokenExpiresAt(accessTokenExpiresAt)
-                .idToken(idToken)
-                .scope(scope)
-                .tokenType(tokenType)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();

--- a/src/main/java/com/footbolic/api/member/entity/MemberEntity.java
+++ b/src/main/java/com/footbolic/api/member/entity/MemberEntity.java
@@ -38,26 +38,17 @@ public class MemberEntity extends BaseEntity {
     @Column(name = "platform", nullable = false, updatable = false, length = 20)
     private String platform;
 
-    @Column(name = "refresh_token", length = 200)
+    @Column(name = "refresh_token", length = 500)
     private String refreshToken;
 
     @Column(name = "refresh_token_expires_at")
     private LocalDateTime refreshTokenExpiresAt;
 
-    @Column(name = "access_token", length = 200)
+    @Transient
     private String accessToken;
 
-    @Column(name = "access_token_expires_at")
+    @Transient
     private LocalDateTime accessTokenExpiresAt;
-
-    @Column(name = "id_token", length = 2000)
-    private String idToken;
-
-    @Column(name = "scope", length = 30)
-    private String scope;
-
-    @Column(name = "token_type", length = 30)
-    private String tokenType;
 
     @Builder.Default
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
@@ -75,9 +66,6 @@ public class MemberEntity extends BaseEntity {
                 .refreshTokenExpiresAt(refreshTokenExpiresAt)
                 .accessToken(accessToken)
                 .accessTokenExpiresAt(accessTokenExpiresAt)
-                .idToken(idToken)
-                .scope(scope)
-                .tokenType(tokenType)
                 .createdAt(getCreatedAt())
                 .updatedAt(getUpdatedAt())
                 .build();

--- a/src/main/java/com/footbolic/api/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/footbolic/api/member/repository/MemberRepositoryCustom.java
@@ -1,5 +1,13 @@
 package com.footbolic.api.member.repository;
 
+import com.footbolic.api.member.entity.MemberEntity;
+
 public interface MemberRepositoryCustom {
-    public boolean existsByIdAtPlatform(String id, String platform);
+
+    MemberEntity findByIdAtPlatform(String idAtPlatform, String platform);
+
+    boolean existsByIdAtPlatform(String idAtPlatform, String platform);
+
+    void updateTokenInfo(MemberEntity member);
+
 }

--- a/src/main/java/com/footbolic/api/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/footbolic/api/member/repository/MemberRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package com.footbolic.api.member.repository;
 
+import com.footbolic.api.member.dto.MemberDto;
+import com.footbolic.api.member.entity.MemberEntity;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -13,12 +15,30 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public boolean existsByIdAtPlatform(String id, String platform) {
+    public MemberEntity findByIdAtPlatform(String idAtPlatform, String platform) {
+        return queryFactory.selectFrom(memberEntity)
+                .where(
+                        memberEntity.idAtProvider.eq(idAtPlatform)
+                                .and(memberEntity.platform.eq(platform))
+                ).fetchFirst();
+    }
+
+    @Override
+    public boolean existsByIdAtPlatform(String idAtPlatform, String platform) {
 
         return !queryFactory.selectFrom(memberEntity)
                 .where(
-                        memberEntity.idAtProvider.eq(id)
+                        memberEntity.idAtProvider.eq(idAtPlatform)
                                 .and(memberEntity.platform.eq(platform))
                 ).fetch().isEmpty();
+    }
+
+    @Override
+    public void updateTokenInfo(MemberEntity member) {
+        queryFactory.update(memberEntity)
+                .set(memberEntity.refreshToken, member.getRefreshToken())
+                .set(memberEntity.refreshTokenExpiresAt, member.getRefreshTokenExpiresAt())
+                .where(memberEntity.id.eq(member.getId()))
+                .execute();
     }
 }

--- a/src/main/java/com/footbolic/api/member/service/MemberService.java
+++ b/src/main/java/com/footbolic/api/member/service/MemberService.java
@@ -11,12 +11,16 @@ public interface MemberService {
 
     MemberDto findById(String id);
 
+    MemberDto findByIdAtPlatform(String idAtPlatform, String platform);
+
     MemberDto saveMember(MemberDto role);
 
     void deleteMember(String id);
 
     boolean existsById(String id);
 
-    boolean existsByIdAtPlatform(String id, String platform);
+    boolean existsByIdAtPlatform(String idAtPlatform, String platform);
+
+    void updateTokenInfo(MemberDto member);
 
 }

--- a/src/main/java/com/footbolic/api/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/footbolic/api/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.footbolic.api.member.service;
 import com.footbolic.api.member.repository.MemberRepository;
 import com.footbolic.api.member.dto.MemberDto;
 import com.footbolic.api.member.entity.MemberEntity;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
@@ -23,6 +25,11 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberDto findById(String id) {
         return memberRepository.findById(id).map(MemberEntity::toDto).orElse(null);
+    }
+
+    @Override
+    public MemberDto findByIdAtPlatform(String idAtPlatform, String platform) {
+        return memberRepository.findByIdAtPlatform(idAtPlatform, platform).toDto();
     }
 
     @Override
@@ -42,8 +49,13 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public boolean existsByIdAtPlatform(String id, String platform) {
-        return memberRepository.existsByIdAtPlatform(id, platform);
+    public boolean existsByIdAtPlatform(String idAtPlatform, String platform) {
+        return memberRepository.existsByIdAtPlatform(idAtPlatform, platform);
+    }
+
+    @Override
+    public void updateTokenInfo(MemberDto member) {
+        memberRepository.updateTokenInfo(member.toEntity());
     }
 
 }

--- a/src/main/java/com/footbolic/api/sign/controller/SignController.java
+++ b/src/main/java/com/footbolic/api/sign/controller/SignController.java
@@ -1,0 +1,159 @@
+package com.footbolic.api.sign.controller;
+
+import com.footbolic.api.common.entity.BaseResponse;
+import com.footbolic.api.common.entity.ErrorResponse;
+import com.footbolic.api.common.entity.SuccessResponse;
+import com.footbolic.api.member.dto.MemberDto;
+import com.footbolic.api.member.service.MemberService;
+import com.footbolic.api.util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Tag(name = "로그인 API")
+@RequestMapping("/sign")
+@RequiredArgsConstructor
+@RestController
+@Slf4j
+public class SignController {
+
+    private final MemberService memberService;
+
+    private final JwtUtil jwtUtil;
+
+    @Operation(summary = "로그인 처리 및 토큰 발급", description = "로그인 처리 후 access token과 refresh token을 발급한다.")
+    @Parameter(name = "paramMember", description = "플랫폼 정보와 플랫폼에서 발급된 id 정보", required = true)
+    @PostMapping("/in")
+    public ResponseEntity<BaseResponse> signIn(
+            HttpServletResponse response,
+            @RequestBody MemberDto paramMember
+    ) {
+        if (paramMember == null ||
+                (paramMember.getIdAtProvider() == null || paramMember.getIdAtProvider().isEmpty()) ||
+                (paramMember.getPlatform() == null || paramMember.getPlatform().isEmpty())
+        ) {
+            return ResponseEntity.badRequest().body(new ErrorResponse("잘못된 회원정보입니다."));
+        }
+
+        if (memberService.existsByIdAtPlatform(paramMember.getIdAtProvider(), paramMember.getPlatform())) {
+            MemberDto member = memberService.findByIdAtPlatform(paramMember.getIdAtProvider(), paramMember.getPlatform());
+
+            Map<String, Object> result = new HashMap<>();
+
+            Date accessExpiration = jwtUtil.getAccessExpiration();
+            String accessToken = jwtUtil.generateAccessToken(member, accessExpiration);
+            result.put("access_token", accessToken);
+            result.put("expires_at", LocalDateTime.ofInstant(accessExpiration.toInstant(), ZoneId.systemDefault()));
+            result.put("nickname", member.getNickname());
+
+            Date refreshExpiration = jwtUtil.getRefreshExpiration();
+            String refreshToken = jwtUtil.generateRefreshToken(member, refreshExpiration);
+
+            jwtUtil.issueRefreshToken(response, refreshToken);
+
+            member.setRefreshToken(refreshToken);
+            member.setRefreshTokenExpiresAt(jwtUtil.toLocalDateTime(refreshExpiration));
+
+            memberService.updateTokenInfo(member);
+
+            return ResponseEntity.ok(new SuccessResponse(result));
+        } else {
+            return ResponseEntity.badRequest().body(new ErrorResponse("잘못된 회원정보입니다."));
+        }
+    }
+
+    @Operation(summary = "로그아웃 처리", description = "로그아웃 처리를 한다.")
+    @PostMapping("/out")
+    public ResponseEntity<BaseResponse> signOut(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        MemberDto member = jwtUtil.resolveAccessToken(accessToken);
+
+        if (member != null) {
+            jwtUtil.removeRefreshToken(response);
+            memberService.updateTokenInfo(MemberDto.builder().id(member.getId()).build());
+
+            return ResponseEntity.ok(new SuccessResponse(""));
+        } else {
+            return ResponseEntity.badRequest().body(new ErrorResponse("로그아웃할 회원이 존재하지 않습니다."));
+        }
+    }
+
+    @Operation(summary = "로그인 상태 확인", description = "Refresh Token 존재 여부를 확인한다.")
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/check")
+    public BaseResponse check(
+            HttpServletRequest request
+    ) {
+        String refreshToken = jwtUtil.extractRefreshToken(request);
+
+        Map<String, Boolean> result = new HashMap<>();
+        result.put("check_result", refreshToken != null && !refreshToken.isEmpty() && jwtUtil.validateToken(refreshToken));
+
+        return new SuccessResponse(result);
+    }
+
+    @Operation(summary = "Access Token 갱신", description = "Refresh Token을 검증한 후 Access Token을 갱신한다.")
+    @PostMapping("/renew")
+    public ResponseEntity<BaseResponse> renew(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String refreshToken = jwtUtil.extractRefreshToken(request);
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            jwtUtil.removeRefreshToken(response);
+            return ResponseEntity.badRequest().body(new ErrorResponse("유효하지 않은 토큰입니다."));
+        }
+
+        MemberDto tokenMember = Optional.of(refreshToken)
+                .filter(jwtUtil::validateToken)
+                .map(jwtUtil::resolveRefreshToken)
+                .filter(e -> e.getRefreshTokenExpiresAt().isAfter(LocalDateTime.now()))
+                .filter(e -> e.getId() != null && !e.getId().isEmpty())
+                .orElse(null);
+
+        if (tokenMember == null) {
+            jwtUtil.removeRefreshToken(response);
+            return ResponseEntity.badRequest().body(new ErrorResponse("회원정보가 없는 토큰입니다."));
+        }
+
+        MemberDto member = memberService.findById(tokenMember.getId());
+
+        if (member.getRefreshToken() != null && member.getRefreshToken().equals(refreshToken)) {
+
+            Map<String, Object> result = new HashMap<>();
+
+            Date accessExpiration = jwtUtil.getAccessExpiration();
+            String accessToken = jwtUtil.generateAccessToken(member, accessExpiration);
+
+            result.put("access_token", accessToken);
+            result.put("expires_at", LocalDateTime.ofInstant(accessExpiration.toInstant(), ZoneId.systemDefault()));
+            result.put("nickname", member.getNickname());
+
+            return ResponseEntity.ok(new SuccessResponse(result));
+        } else {
+            jwtUtil.removeRefreshToken(response);
+            memberService.updateTokenInfo(MemberDto.builder().id(member.getId()).build());
+
+            return ResponseEntity.ok(new ErrorResponse("유효하지 않은 토큰입니다."));
+        }
+    }
+}

--- a/src/main/java/com/footbolic/api/util/JwtUtil.java
+++ b/src/main/java/com/footbolic/api/util/JwtUtil.java
@@ -1,0 +1,226 @@
+package com.footbolic.api.util;
+
+import com.footbolic.api.member.dto.MemberDto;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+
+    private static final String BEARER_TYPE = "Bearer";
+
+    private final String ID_CLAIM = "id";
+
+    private final String AUTH_CLAIM = "auth";
+
+    private final String PLATFORM_CLAIM = "platform";
+
+    private final String ID_AT_PROVIDER_CLAIM = "idAtProvider";
+
+    private static final Long REFRESH_TOKEN_EXPIRES_IN = 180 * 24 * 60 * 60 * 1000L;
+
+    private static final Long ACCESS_TOKEN_EXPIRES_IN =   30 * 60 * 1000L;
+
+    private final Key key;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * 현재시간 기준 Refresh Token의 만료시간을 반환한다
+     * @return Refresh Token 만료시간
+     */
+    public Date getRefreshExpiration() {
+        return new Date(new Date().getTime() + REFRESH_TOKEN_EXPIRES_IN);
+    }
+
+    /**
+     * 현재시간 기준 Access Token의 만료시간을 반환한다
+     * @return Access Token 만료시간
+     */
+    public Date getAccessExpiration() {
+        return new Date(new Date().getTime() + ACCESS_TOKEN_EXPIRES_IN);
+    }
+
+    /**
+     * 회원 식별번호로 RefreshToken 생성
+     */
+    public String generateRefreshToken(MemberDto member, Date expiration) {
+        return Jwts.builder()
+                .claim(ID_CLAIM, member.getId())
+                .setIssuedAt(new Date())
+                .setExpiration(expiration)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 회원정보로 AccessToken 생성
+     */
+    public String generateAccessToken(MemberDto member, Date expiration) {
+        return Jwts.builder()
+                .setSubject(member.getNickname())
+                .claim(ID_CLAIM, member.getId())
+                .claim(AUTH_CLAIM, member.getRoleId())
+                .claim(PLATFORM_CLAIM, member.getPlatform())
+                .claim(ID_AT_PROVIDER_CLAIM, member.getIdAtProvider())
+                .setIssuedAt(new Date())
+                .setExpiration(expiration)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Access Token에 들어있는 정보 복호화
+     */
+    public MemberDto resolveAccessToken(String accessToken) {
+
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTH_CLAIM) == null) {
+            log.error("권한정보가 없는 토큰입니다.");
+            return null;
+        }
+
+        return MemberDto.builder()
+                .id(claims.get(ID_CLAIM).toString())
+                .platform(claims.get(PLATFORM_CLAIM).toString())
+                .idAtProvider(claims.get(ID_AT_PROVIDER_CLAIM).toString())
+                .roleId(claims.get(AUTH_CLAIM).toString())
+                .accessTokenExpiresAt(LocalDateTime.ofInstant(claims.getExpiration().toInstant(), ZoneId.systemDefault()))
+                .build();
+    }
+
+    /**
+     * Refresh Token에 들어있는 정보 복호화
+     */
+    public MemberDto resolveRefreshToken(String refreshToken) {
+
+        Claims claims = parseClaims(refreshToken);
+
+        return MemberDto.builder()
+                .id(claims.get(ID_CLAIM).toString())
+                .refreshTokenExpiresAt(LocalDateTime.ofInstant(claims.getExpiration().toInstant(), ZoneId.systemDefault()))
+                .build();
+    }
+
+    /**
+     * 토큰 정보를 검증하는 메서드
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 body에 실린 데이터 추출
+     */
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    /**
+     * 헤더에서 액세스 토큰 추출
+     */
+    public String extractAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * 쿠키에서 Refresh Token 을 추출한다.
+     * @param request HttpServletRequest 객체
+     * @return 쿠키에서 추출한 Refresh Token
+     */
+    public String extractRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName() != null && cookie.getName().equals(REFRESH_TOKEN_COOKIE_NAME))
+                    return cookie.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Date 객체를 LocalDateTime 객체로 변환한다.
+     * @param date 변환할 Date 객체
+     * @return 변환된 LocalDateTime 객체
+     */
+    public LocalDateTime toLocalDateTime(Date date) {
+        return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+    }
+
+    /**
+     * 쿠키에 Refresh Token을 발급한다
+     * @param response HttpServletResponse 객체
+     * @param refreshToken 발급할 Refresh Tokens
+     */
+    public void issueRefreshToken(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge((180 * 24 * 60 * 60) - (60 * 60));
+        cookie.setPath("/");
+        cookie.setDomain("localhost");
+        cookie.setAttribute("SameSite", "none");
+
+        response.addCookie(cookie);
+    }
+
+    /**
+     * 쿠키에 저장된 Refresh Token을 제거한다
+     * @param response HttpServletResponse 객체
+     */
+    public void removeRefreshToken(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, "");
+
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+
+        response.addCookie(cookie);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,6 @@ springdoc.swagger-ui.operations-sorter=method
 
 # json mapper setting
 spring.mvc.converters.preferred-json-mapper=gson
+
+# jwt
+jwt.secret=zKLgJ7fGHJ8CsiWoc4cp6EZ3lyVVH7MwM6Z2l7Si9svasCuv7HgUNLsbUofe


### PR DESCRIPTION
### 관련 이슈
- #17 

### 수정 사항
- JWT 발급 세팅
- 로그인 로그아웃 API 생성
- 로그인 상태 체크 API 및 Access Token 재발급 API 생성

### 기타 참고 사항
- 토큰은 Refresh Token, Access Token 두가지로 구성
- Access Token은 응답으로 반환
- Refresh Token은 쿠키에 HttpOnly로 설정해서 제공
